### PR TITLE
bestblock tracker: better handle connection drops

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -154,6 +154,7 @@ func (c *Core) Run() {
 				if err1 != nil {
 					log.Fatal(err1)
 				}
+				time.Sleep(2 * time.Second)
 				continue
 			}
 

--- a/eth/bestblock/http.go
+++ b/eth/bestblock/http.go
@@ -7,20 +7,20 @@ func (b *Tracker) runHTTP() {
 	for {
 		select {
 		case <-time.Tick(b.config.PollInterval):
-			old := b.BestBlock()
-			b.getBlockNumber()
-
-			newBlock := b.BestBlock()
-			if old < newBlock {
-				for i := old + 1; i <= newBlock; i++ {
-					b.publish(i)
-				}
-			} else {
-				b.publish(newBlock)
-			}
-
+			b.getBestHTTP()
 		case <-b.stopChan:
 			return
 		}
+	}
+}
+
+// getBestHTTP checks the current best block and publishes events for all the blocks between the previous and the new best block
+func (b *Tracker) getBestHTTP() {
+	oldBest := b.BestBlock()
+	b.getBlockNumber()
+	newBest := b.BestBlock()
+
+	for i := oldBest + 1; i <= newBest; i++ {
+		b.publish(i)
 	}
 }

--- a/eth/bestblock/ws.go
+++ b/eth/bestblock/ws.go
@@ -9,28 +9,28 @@ import (
 
 // runWS uses a websocket subscription to get new block headers as soon as they appear
 func (b *Tracker) runWS() {
-	for {
-		heads, err := b.conn.NewHeadsSubscription()
-		if err != nil {
-			log.Error(err)
-			time.Sleep(5 * time.Second)
-			continue
-		}
-
-		b.consumeWSSubscription(heads)
-
-		if b.stopped {
-			return
-		}
-
-		log.Warn("WS connection closed;")
+	heads, err := b.conn.NewHeadsSubscription()
+	if err != nil {
+		log.Error(err)
 		time.Sleep(5 * time.Second)
+		return
 	}
+
+	b.consumeWSSubscription(heads)
+
+	if b.stopped {
+		return
+	}
+
+	log.Warn("WS connection closed")
 }
 
 // consumeWSSubscription consumes a block headers stream coming from the websocket subscription until the channel is closed
 // and saves the new blocks in the dedicated variable on the Tracker struct
 func (b *Tracker) consumeWSSubscription(blocks chan *types.BlockHeader) {
+	b.subscribed = true
+	defer func() { b.subscribed = false }()
+
 	for {
 		select {
 		case block := <-blocks:


### PR DESCRIPTION
Before this update, if the client connection would crash, the tracker wouldn't be able to recover. 
With this change, it will recreate the connection in case it crashes while also taking care of publishing the blocks skipped while the connection was down.